### PR TITLE
Build: Added connection state recovery feature

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -20,18 +20,32 @@ const App = () => {
       ]);
     };
 
-    if (user) {
-      socket.connect();
-      socket.on("message:receive", handleMessage);
-    }
+    socket.on("connect", () => {
+      console.log("recovered?", socket.id, socket.recovered);
+
+      // closes the low-level connection and trigger a reconnection
+      // To use in test suite for testing purposes
+      // setTimeout(() => {
+      //   socket.io.engine.close();
+      // }, Math.random() * 5000 + Math.random() * 5000);
+    });
+
+    socket.on("recovery:enable", () => {
+      console.log("recovery has been enabled");
+    });
+
+    socket.on("message:receive", handleMessage);
+
+    socket.on("disconnect", (reason) => {
+      console.log(`Disconnected: ${reason}`);
+    });
 
     return () => {
+      socket.off("connect");
       socket.off("message:receive", handleMessage);
-      if (socket.connected) {
-        socket.disconnect();
-      }
+      socket.off("disconnect");
     };
-  }, [user]);
+  }, []);
 
   const handleUsernameSubmit = (username) => {
     setUser(username);

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  // <React.StrictMode>
+  <App />
+  // </React.StrictMode>
 );

--- a/client/src/socket.js
+++ b/client/src/socket.js
@@ -1,7 +1,14 @@
 import { io } from "socket.io-client";
 
-const URL = "WebSoc-ALBWe-xZnY5RFZxkZH-132878851.us-east-1.elb.amazonaws.com";
+// const URL = "WebSoc-ALBWe-NV60NiEyhF9D-501949085.us-east-1.elb.amazonaws.com";
+const URL = "localhost:8000";
 
 export const socket = io(URL, {
+  autoConnect: true, // required for connection state recovery
   transports: ["websocket"], // Include both websocket and polling as fallback
+  reconnection: true, // Enable reconnection attempts
+  reconnectionAttempts: 5, // Number of attempts before giving up
+  reconnectionDelay: 5000, // Delay between reconnections
+  reconnectionDelayMax: 5000, // Maximum delay between reconnections
+  timeout: 20000, // Before a connection attempt is considered failed
 });

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,11 +13,13 @@
         "@aws-sdk/client-sqs": "^3.609.0",
         "@aws-sdk/lib-dynamodb": "^3.610.0",
         "@socket.io/redis-adapter": "^8.3.0",
+        "@socket.io/redis-streams-adapter": "^0.2.2",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "dynamoose": "^4.0.1",
         "express": "^4.19.2",
         "ioredis": "^5.4.1",
+        "redis": "^4.6.15",
         "socket.io": "^4.7.5",
         "uuid": "^10.0.0",
         "vitest": "^1.6.0"
@@ -1234,6 +1236,74 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@msgpack/msgpack": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
+      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.5.17",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.5.17.tgz",
+      "integrity": "sha512-IPvU9A31qRCZ7lds/x+ksuK/UMndd0EASveAvCvEtFFKIZjZ+m/a4a0L7S28KEWoR5ka8526hlSghDo4Hrc2Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.6.tgz",
+      "integrity": "sha512-rcZO3bfQbm2zPRpqo82XbW8zg4G/w4W3tI7X8Mqleq9goQjAGLL7q/1n1ZX4dXEAmORVZ4s1+uKLaUOg7LrUhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.6.tgz",
+      "integrity": "sha512-mZXCxbTYKBQ3M2lZnEddwEAks0Kc7nauire8q20oA0oA/LoA+E/b5Y5KZn232ztPb1FkIGqo12vh3Lf+Vw5iTw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.5.tgz",
+      "integrity": "sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.18.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.0.tgz",
@@ -2060,6 +2130,45 @@
       }
     },
     "node_modules/@socket.io/redis-adapter/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
+    },
+    "node_modules/@socket.io/redis-streams-adapter": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/redis-streams-adapter/-/redis-streams-adapter-0.2.2.tgz",
+      "integrity": "sha512-BMPa6oGC0wFgpMXoGksbJ75zMBwk+79pxjHc2YusdoK+X0BxN4fTsqEBuFV7yeXi9ekbi87rwlsT61+WZGVW9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@msgpack/msgpack": "~2.8.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "socket.io-adapter": "^2.5.4"
+      }
+    },
+    "node_modules/@socket.io/redis-streams-adapter/node_modules/debug": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@socket.io/redis-streams-adapter/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
@@ -3032,6 +3141,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -3814,6 +3932,23 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.6.15",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.6.15.tgz",
+      "integrity": "sha512-2NtuOpMW3tnYzBw6S8mbXSX7RPzvVFCA2wFJq9oErushO2UeBkxObk+uvo7gv7n0rhWeOj/IzrHO8TjcFlRSOg==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.5.17",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.6",
+        "@redis/search": "1.1.6",
+        "@redis/time-series": "1.0.5"
       }
     },
     "node_modules/redis-errors": {
@@ -4647,6 +4782,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -18,11 +18,13 @@
     "@aws-sdk/client-sqs": "^3.609.0",
     "@aws-sdk/lib-dynamodb": "^3.610.0",
     "@socket.io/redis-adapter": "^8.3.0",
+    "@socket.io/redis-streams-adapter": "^0.2.2",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "dynamoose": "^4.0.1",
     "express": "^4.19.2",
     "ioredis": "^5.4.1",
+    "redis": "^4.6.15",
     "socket.io": "^4.7.5",
     "uuid": "^10.0.0",
     "vitest": "^1.6.0"

--- a/server/src/config/redis.ts
+++ b/server/src/config/redis.ts
@@ -10,12 +10,6 @@ const redisConfig = {
   port: redisPort,
 };
 
-export const sub = new Redis(redisConfig)
-  .on("ready", () => console.log("Subscriber Redis client is ready"))
-  .on("error", (error) => {
-    console.error("Subscriber Redis client error:", error);
-  });
-
 export const pub = new Redis(redisConfig)
   .on("ready", () => console.log("Publisher client is ready"))
   .on("error", (error) => {

--- a/server/src/handlers/disconnection.ts
+++ b/server/src/handlers/disconnection.ts
@@ -1,8 +1,8 @@
 import { Socket } from "socket.io";
 
 export const registerDisconnection = (socket: Socket) => {
-  const disconnect = () => {
-    console.log(`Socket ${socket.id} disconnected`);
+  const disconnect = (reason: string) => {
+    console.log(`Socket ${socket.id} disconnected: ${reason}`);
   };
 
   socket.on("disconnect", disconnect);


### PR DESCRIPTION
# Frontend
- Moved socket events into mount useEffect
- Revised manual socket connection to auto-connection; removed `socket.connect()` from `App.jsx` and added `autoConnect: true` property to `socket`
- Added connection state recovery features to `socket`

# Backend
- Updated Redis adapter to Redis Streams adapter to allow for connection state recovery and pub/sub functionality; no longer need `sub`
- Added connection state recovery features to `io` Socket.io server
- Added a `recovery:enable` emit event simply to initialize the offset on the client side, as required for connection state recovery. _Receiving this on the client side is not strictly required, but the send from server side **is** required._