### PR TITLE
Updated cerebellum SDK to latest version, to fix bug.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
-        "@cerebellum/sdk": "^1.0.0",
+        "@cerebellum/sdk": "^1.0.2",
         "dotenv": "^16.4.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -395,9 +395,9 @@
       }
     },
     "node_modules/@cerebellum/sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@cerebellum/sdk/-/sdk-1.0.0.tgz",
-      "integrity": "sha512-9Hb3Acdz3s3buaQWyDi4imZqTZhAXP+6MGrwwUEiDE/NKYLJmRS3vvfusTkpIMBIk2RM1mtFtFcppJYfDEMNWA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@cerebellum/sdk/-/sdk-1.0.2.tgz",
+      "integrity": "sha512-+Rj2kPluZnFIfR5I5P0CRjBCkIcvpFqtJo9dOjBQT0IBUfRMBKWJ2q9J/9wSCoUsiiHkBAGbjzrBninCHudenA==",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@cerebellum/sdk": "^1.0.0",
+    "@cerebellum/sdk": "^1.0.2",
     "dotenv": "^16.4.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"


### PR DESCRIPTION
Updated SDK of cerebellum to the latest version, to fix bug in the SDK. 

The SDK now pulls the image from docker, instead of ECS.

The bug fixed by updating the SDK happens when a user is disconnected.